### PR TITLE
Add simple installer for Samsung battery module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # ELPM482-00005-for-Victron
-Provides support for Samsung ELPM482-00005 batteries in Victron GX devices using a USB to RS485 adapter
+
+This package installs support for Samsung ELPM482-00005 batteries on Victron GX
+devices. It adds a new `samsung_battery` module to Victron's
+`dbus-modbus-client` service and patches `dbus-modbus-client.py` so the module
+is imported automatically.
+
+## Installation
+1. Copy this repository to your GX device.
+2. Run `./install.sh` to copy `samsung_battery.py` to
+   `/opt/victronenergy/dbus-modbus-client` and patch `dbus-modbus-client.py`
+   with `import samsung_battery`.
+3. Optionally, arrange for `check_install.sh` to run at boot (for example from
+   `/data/rc.local`). It will reinstall the files if the import line is removed
+   during a system update.

--- a/check_install.sh
+++ b/check_install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Run this script on boot to ensure samsung battery support persists after upgrades
+set -e
+DIR="$(dirname "$0")"
+TARGET=/opt/victronenergy/dbus-modbus-client
+
+if ! grep -q '^import samsung_battery' "$TARGET/dbus-modbus-client.py"; then
+    echo "Reinstalling samsung battery support" >&2
+    "$DIR/install.sh"
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+TARGET=/opt/victronenergy/dbus-modbus-client
+THIS_DIR="$(dirname "$0")"
+
+mkdir -p "$TARGET"
+install -m 0644 "$THIS_DIR/samsung_battery.py" "$TARGET/"
+
+# ensure import line is present
+if ! grep -q '^import samsung_battery' "$TARGET/dbus-modbus-client.py"; then
+    sed -i '/import victron_em/a import samsung_battery' "$TARGET/dbus-modbus-client.py"
+fi
+
+echo "Samsung battery support installed to $TARGET"


### PR DESCRIPTION
## Summary
- keep only Samsung battery module and install scripts
- remove bundled dbus-modbus-client sources
- update README for new installation procedure

## Testing
- `python3 -m py_compile samsung_battery.py`


------
https://chatgpt.com/codex/tasks/task_e_6860d4b80ac48322831e965c845e93de